### PR TITLE
First infra

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -38,12 +38,20 @@ poa_validators_public_keys:
 nodes_eth_public_keys:
   - 'edcbbfc8b785aa3ada3d7e8cc06a3ec1aa50676b'
   - '15641b0ec20db6b271af3db21e56a9a64eabb69c'
+  - 'a4025d5335b49fd7490d2007ed0afe989c599bc0'
+  - '44322f070f700979fd738e0c81033fe23e92422d'
 
 nodes_layout:
   'metal-01.he-eu-hel1.codex.test':
     validator_index: 0
+    instances:
+      - { pubkey: 0, build_start: '13:00:00' }
+      - { pubkey: 2, build_start: '14:00:00' }
   'metal-02.he-eu-hel1.codex.test':
     validator_index: 1
+    instances:
+      - { pubkey: 1, build_start: '13:00:00' }
+      - { pubkey: 3, build_start: '14:00:00' }
 
 geth_validator_account: '{{ poa_validators_public_keys[nodes_layout[inventory_hostname]["validator_index"]] }}'
 geth_account_json_file: '{{ geth_cont_vol }}/keys/{{ geth_validator_account }}'
@@ -51,3 +59,11 @@ geth_account_json_file: '{{ geth_cont_vol }}/keys/{{ geth_validator_account }}'
 geth_bootnodes:
   - "enode://1f20fc74458821e63f3ef2af550b266efcc079b1f9c2d774cb6eff45f8310130831d67ab4152675b3411c85f0b814afc818f7acf563e05cdbb593fb05dd6c705@65.21.196.45:30303"
   - "enode://1b78da25b32a930278682709972181b9c80d0f37d7e62a4eaf3cfc324142a779518de7ff11f1d9a8df5b86fd3cc3db0cc1222e9d3f116f039e74bd7865698483@65.21.196.46:30303"
+
+# codex
+codex_service_name: 'codex-node-{{ "%02d"|format(idx|int+1) }}'
+codex_rest_port: '{{ 5052 + idx|int }}'
+codex_listening_port: '{{ 9000 + idx|int }}'
+# main is broken rn
+codex_repo_branch: 'erassure'
+codex_eth_public_key: '{{ nodes_eth_public_keys[node["pubkey"]] }}'

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -12,6 +12,7 @@ wireguard_consul_acl_token: '{{lookup("bitwarden", "consul/acl-tokens", field="w
 # Custom SSH accounts for Codex fleet, should start from UID 8000.
 bootstrap__active_extra_users:
   - { name: dryajov,  uid: 8004, admin: true, key: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBjhsSxUXSQBv6PFEwE9TYG0TeuzabRipy/IoIS33BTt dryajov@status.im' }
+  - { name: michael,  uid: 8005, admin: true, key: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL6SqXrxfGl6Lkb7W1P9+ApR7z17QwhL+4DiVaVEGQCX michael@cobra-la' }
   - { name: tanguy,   uid: 8007, admin: true, key: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC5wbFl7pJ+Vl6Csw7gh50+fYiuH/HAV+dLN0997isreWsrr+H/6uTDwvtYmbfG8Nrr1NVzFjrGXTUhF3lmSTzC7l+xdlUE9QoOumTF7OI7A79Wp0B3kzKk8YAKskyCtz4JUtvJaExJhxTy385dbXXrS/hV1lfciLiDp+rkg+EkCTedMeWVWhaJpoaS8OY/UzoYfPClFmGM5sAMF9UNPPIGjvCibTdt2uGerOki4FIcgqXARzOc1J6bEA1qTeYRh1wjv6KC3AyLRsLEooXqoviVYUm0bVLMZteTpIdY5N61FlytPcFpjAla9SCJYwPd3ud1hdurcQ5+wHuaAyKksCa6Qnhf/vX9LMFwbOkOqGLNKY5sdRhDyN5xbNdfk4jnY3E+8Z0CNmSV+dpmpwcOahNTB65t5zqcU/NXynFbALf3j3A9uklQ5Or1Y8ytnzjfSko+TQZHBr5/w810vxS3VNS470wGjyzhyVKSg1qNJXb+m2GLT9k5lBxnl7j3o8CLbOs= tavon@wheatley' }
 
 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -13,3 +13,41 @@ wireguard_consul_acl_token: '{{lookup("bitwarden", "consul/acl-tokens", field="w
 bootstrap__active_extra_users:
   - { name: dryajov,  uid: 8004, admin: true, key: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBjhsSxUXSQBv6PFEwE9TYG0TeuzabRipy/IoIS33BTt dryajov@status.im' }
   - { name: tanguy,   uid: 8007, admin: true, key: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC5wbFl7pJ+Vl6Csw7gh50+fYiuH/HAV+dLN0997isreWsrr+H/6uTDwvtYmbfG8Nrr1NVzFjrGXTUhF3lmSTzC7l+xdlUE9QoOumTF7OI7A79Wp0B3kzKk8YAKskyCtz4JUtvJaExJhxTy385dbXXrS/hV1lfciLiDp+rkg+EkCTedMeWVWhaJpoaS8OY/UzoYfPClFmGM5sAMF9UNPPIGjvCibTdt2uGerOki4FIcgqXARzOc1J6bEA1qTeYRh1wjv6KC3AyLRsLEooXqoviVYUm0bVLMZteTpIdY5N61FlytPcFpjAla9SCJYwPd3ud1hdurcQ5+wHuaAyKksCa6Qnhf/vX9LMFwbOkOqGLNKY5sdRhDyN5xbNdfk4jnY3E+8Z0CNmSV+dpmpwcOahNTB65t5zqcU/NXynFbALf3j3A9uklQ5Or1Y8ytnzjfSko+TQZHBr5/w810vxS3VNS470wGjyzhyVKSg1qNJXb+m2GLT9k5lBxnl7j3o8CLbOs= tavon@wheatley' }
+
+
+# geth part
+
+# Don't have access to bitwarden
+geth_account_pass: 'verysafe'
+geth_port: 30303
+geth_network_id: 73738
+
+geth_sync_mode: 'full'
+
+geth_init_enabled: true
+geth_init_url: 'https://gist.githubusercontent.com/Menduist/f1de66b9afe9ec9fed20491e1dec1ab4/raw/115bc91d1cb4016c794fb9578686215f652c76a4/dagger%2520testnet%2520genesis'
+geth_init_sha256: '0d48d1be38a8d7b6cc4ddbef339f0e57eb7403736b4f6ecab8ca141c71925dd8'
+geth_miner_enabled: true
+
+geth_consul_enabled: false
+
+poa_validators_public_keys:
+  - '65ff54a53d45b83f2d9bb81f83a70dab1c86007a'
+  - '5b7d8b89c3db49ffbb428bb4988c38a6fe6a5843'
+
+nodes_eth_public_keys:
+  - 'edcbbfc8b785aa3ada3d7e8cc06a3ec1aa50676b'
+  - '15641b0ec20db6b271af3db21e56a9a64eabb69c'
+
+nodes_layout:
+  'metal-01.he-eu-hel1.codex.test':
+    validator_index: 0
+  'metal-02.he-eu-hel1.codex.test':
+    validator_index: 1
+
+geth_validator_account: '{{ poa_validators_public_keys[nodes_layout[inventory_hostname]["validator_index"]] }}'
+geth_account_json_file: '{{ geth_cont_vol }}/keys/{{ geth_validator_account }}'
+
+geth_bootnodes:
+  - "enode://1f20fc74458821e63f3ef2af550b266efcc079b1f9c2d774cb6eff45f8310130831d67ab4152675b3411c85f0b814afc818f7acf563e05cdbb593fb05dd6c705@65.21.196.45:30303"
+  - "enode://1b78da25b32a930278682709972181b9c80d0f37d7e62a4eaf3cfc324142a779518de7ff11f1d9a8df5b86fd3cc3db0cc1222e9d3f116f039e74bd7865698483@65.21.196.46:30303"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -64,6 +64,5 @@ geth_bootnodes:
 codex_service_name: 'codex-node-{{ "%02d"|format(idx|int+1) }}'
 codex_rest_port: '{{ 5052 + idx|int }}'
 codex_listening_port: '{{ 9000 + idx|int }}'
-# main is broken rn
-codex_repo_branch: 'erassure'
+codex_repo_branch: 'main'
 codex_eth_public_key: '{{ nodes_eth_public_keys[node["pubkey"]] }}'

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -1,0 +1,39 @@
+---
+- name: Verify Ansible versions
+  hosts: all
+  tags: always
+  become: false
+  run_once: true
+  gather_facts: false
+  tasks:
+    - local_action: command ./versioncheck.py
+      changed_when: false
+
+- name: Setup geth symlink
+  become: true
+  hosts: all
+  tasks:
+    - copy:
+        dest: '/docker/geth/node/keys/account.addr'
+        content: '{{ geth_validator_account }}'
+        owner: dockremap
+        group: docker
+        mode: 0640
+
+- name: Configure geth nodes
+  become: true
+  hosts: all
+  serial: 1
+  roles:
+    - { role: swap-file,                tags: swap-file }
+    - { role: infra-role-geth,          tags: infra-role-geth }
+
+- name: Configure codex instances
+  become: true
+  hosts: all
+  tasks:
+    - include_role: name=infra-role-nim-codex
+      with_items: '{{ nodes_layout[hostname]["instances"] }}'
+      loop_control:
+        loop_var: node
+        index_var: idx

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -23,3 +23,8 @@
   src: git@github.com:status-im/infra-role-consul-service.git
   version: 2b3d4e53856d6cc91ae5c5a342fd12f2bb96aa88
   scm: git
+
+- name: infra-role-geth
+  src: git@github.com:status-im/infra-role-geth.git
+  version: 9647eaeaf5331fde07a33fe9d5194e78e3c5cd95
+  scm: git

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -28,3 +28,13 @@
   src: git@github.com:status-im/infra-role-geth.git
   version: 9647eaeaf5331fde07a33fe9d5194e78e3c5cd95
   scm: git
+
+- name: infra-role-nim-codex
+  src: git@github.com:status-im/infra-role-nim-codex.git
+  version: 7353484dcf2c436dad2fe95e77630e0998e8aae2
+  scm: git
+
+- name: systemd-timer
+  src: git@github.com:status-im/infra-role-systemd-timer.git
+  version: c6bbc3d1b4b0ba603d82fa06cd17297d12523182
+  scm: git


### PR DESCRIPTION
I did a first version of the infra, documenting here:
(note, it's already deployed, just using this PR as a documentation basically)

On each server, we need 1 geth instance, running on a custom network
We need:
- One eth account per server to run the PoA
- One eth account per codex instance running.

I've bootstraped the network with two PoA mining accounts.
Every server has every account available to geth (I don't have access to bitwarden, so I synced them manually), and one "main" account which will be used for mining (`geth_validator_account`)

Each codex instance will then be configured with one public key from the available accounts. Note, unlike nimbus, we can't move keys as easily, because each public key will store stuff in it's "data" folder. So each key must stay with it's instance